### PR TITLE
rename all occurences of Friendo_Bot to friendo-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ the above environment variables must be added to the system or a file named `.en
 
 ```bash
 # Clone the repository on the develop branch
-$ git clone -b "develop" https://github.com/fisher60/Friendo_Bot.git
+$ git clone -b "develop" https://github.com/fisher60/friendo-bot.git
 
 # Navigate to the repository directory
-$ cd Friendo_Bot
+$ cd friendo-bot
 
 # Install pipenv through pip or your package manager
 $ pip install pipenv

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -18,7 +18,7 @@ class Help(Cog):
         prefix = self.bot.command_prefix
 
         embed = Embed(
-            title=f"{'-' * (char_repeat // 2)}Friendo_Bot{'-' * (char_repeat // 2)}",
+            title=f"{'-' * (char_repeat // 2)}friendo-bot{'-' * (char_repeat // 2)}",
             url=GITHUB_REPO,
         )
 

--- a/bot/settings.py
+++ b/bot/settings.py
@@ -25,7 +25,7 @@ FRIENDO_API_URL = environ.get("FRIENDO_API_URL", "http://dev.friendo.dev/api/")
 
 VERSION = "1.2"
 
-GITHUB_REPO = "https://github.com/fisher60/Friendo_Bot"
+GITHUB_REPO = "https://github.com/fisher60/friendo-bot"
 
 AOC_LEADERBOARD_LINK = "https://adventofcode.com/2021/leaderboard/private/view/991705.json"
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
 
   bot:
-    image: ghcr.io/Fisher60/Friendo_Bot:latest
+    image: ghcr.io/Fisher60/friendo-bot:latest
     tty: true
     env_file: bot.env
     restart: unless-stopped


### PR DESCRIPTION
The repo was renmaed so I have gone through and renamed ever instance of Friendo_Bot to friendo-bot. This should allow deployments to work as well as the help function/anything that uses the repo name.