### PR TITLE
add logging filter to remove log messages containing token

### DIFF
--- a/bot/graphql.py
+++ b/bot/graphql.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import logging
 
 import aiohttp
@@ -8,7 +7,15 @@ import jwt
 
 from bot import settings
 
+
+class LoginTokenLoggingFilter(logging.Filter):
+    """Logging filter to remove api token from logging for friendo api requests"""
+    def filter(self, record):
+        return "token" not in record.getMessage()
+
+
 log = logging.getLogger(__name__)
+log.addFilter(LoginTokenLoggingFilter())
 
 
 class GraphQLClient:
@@ -70,13 +77,6 @@ class GraphQLClient:
         async with self.session.post(self.url, headers=self.headers, **kwargs) as resp:
             resp = await resp.json()
 
-            logging_response_copy = copy.deepcopy(resp)
-
-            # remove api token from response to prevent token from existing in logs
-            # if data was returned and the resp is for a login, censor the token
-            if logging_response_copy["data"] and "login" in logging_response_copy["data"]:
-                logging_response_copy["data"]["login"]["token"] = "token_redacted_for_security"
-
-            log.info(logging_response_copy)
+            log.info(resp)
 
             return resp

--- a/bot/graphql.py
+++ b/bot/graphql.py
@@ -9,8 +9,10 @@ from bot import settings
 
 
 class LoginTokenLoggingFilter(logging.Filter):
-    """Logging filter to remove api token from logging for friendo api requests"""
-    def filter(self, record):
+    """Logging filter to remove api token from logging for friendo api requests."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Returns False if login token is in logging record."""
         return "token" not in record.getMessage()
 
 


### PR DESCRIPTION
This is a temporary fix. In the future we need to still log the login message, but with the token redacted. At the moment, for reasons beyond my understanding, the token redaction was working in dev, but breaks the api in prod. This will be a short term fix.